### PR TITLE
Fix [Violation] Forced reflow while executing

### DIFF
--- a/src/modal.mjs
+++ b/src/modal.mjs
@@ -54,6 +54,7 @@ async function displayModal(fn, ...args) {
     const dialogBodyDiv = document.createElement("div");
     dialogBodyDiv.id = `${CSS_PREFIX}dialog-body`;
     dialog.appendChild(dialogBodyDiv);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
     dialog.showModal();
     const wrappedPromise = Promise.resolve(fn(dialogBodyDiv, abortSignal, ...args)).catch((error) => {
         if (abortSignal.aborted) {


### PR DESCRIPTION
Was getting this warning in the console: [Violation] Forced reflow while executing JavaScript took 36ms

Calling `requestAnimationFrame()` seems to fix this.