### PR TITLE
Sync from template upstream: __FNAME_LINENO__

### DIFF
--- a/jest.setup.mjs
+++ b/jest.setup.mjs
@@ -1,6 +1,7 @@
 import jest from "jest-mock";
 
 Object.assign(global, {
-    alert: jest.fn(),
+    __FNAME_LINENO__: "__FNAME_LINENO__:0",
     _localStorage: { getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn(), clear: jest.fn() },
+    alert: jest.fn(),
 });


### PR DESCRIPTION
This is handled in rollup but caused modules to be unimportable in unit tests due to the variable being undefined. Defining it with a mock value.

Also sorting lines in the file for style.