### PR TITLE
Fix second violation warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,6 @@ that says "Hello World".
 - Revisit dir structure section
 - Revisit entire README
 - New screenshots
+- codecov and README badges like my Python repos
+    - Make GitHub Action step conditional on token variable being set, skip if not, don't fail
+- GitHub pages action

--- a/src/modal.mjs
+++ b/src/modal.mjs
@@ -67,6 +67,7 @@ async function displayModal(fn, ...args) {
         return await Promise.race([wrappedPromise, abortPromise]);
     } finally {
         // Clean up.
+        await new Promise((resolve) => requestAnimationFrame(resolve));
         dialog.close();
         dialog.remove();
         style.remove();

--- a/tests/modal.test.js
+++ b/tests/modal.test.js
@@ -39,9 +39,9 @@ describe("modal.mjs", () => {
         let dialog;
 
         const result = await modal((dialogBodyDiv) => {
-            expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
             dialog = dialogBodyDiv.closest("dialog");
             expect(dialog.open).toBe(true);
+            expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
             expect(document.body.children).toHaveLength(1);
             expect(document.head.children).toHaveLength(1);
             return; // No sleep means the dialog should close immediately after opening.
@@ -49,6 +49,7 @@ describe("modal.mjs", () => {
 
         expect(result).toBeUndefined();
         expect(dialog.open).toBe(false);
+        expect(requestAnimationFrame).toHaveBeenCalledTimes(2);
         expect(document.body.children).toHaveLength(0);
         expect(document.head.children).toHaveLength(0);
     });


### PR DESCRIPTION
Didn't appear before but started to see it now when using the extension on GitHub projects roadmap view. Calling `requestAnimationFrame()` before closing the dialog.

Adding more TODOs.